### PR TITLE
Add deal metadata tooling and fix list parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ export BITRIX_WEBHOOK_URL="https://your-domain.bitrix24.ru/rest/1/yoursecretcode
 запустите MCP сервер:
 
 ```bash
-uvx bitrix24-mcp
+uv run bitrix24-mcp
 ```
 
 Вы увидите логи в консоли, включая информацию о зарегистрированных MCP инструментах и ресурсах.
@@ -62,7 +62,7 @@ uvx bitrix24-mcp
 Для проверки базовой работоспособности интеграции с Bitrix24 API можно запустить тестовый скрипт:
 
 ```bash
-python test_services.py
+uv run python tests/services.py
 ```
 Скрипт выполнит несколько запросов к API Bitrix24 (получение списка контактов, получение контакта по ID, и т.д.) и выведет результаты.
 
@@ -92,8 +92,12 @@ python test_services.py
     *   **Возвращает:** JSON-строка с данными сделки.
 *   `tool://list_deals`
     *   **Описание:** Получение списка сделок с возможностью фильтрации.
-    *   **Параметры:** `active_only: bool = False`, `contact_id: int | None = None`, `company_id: int | None = None`, `limit: int = 50`
+    *   **Параметры:** `active_only: bool = False`, `contact_id: int | None = None`, `company_id: int | None = None`, `limit: int = -1`
     *   **Возвращает:** JSON-строка со списком сделок.
+*   `tool://get_deal_stages`
+    *   **Описание:** Получение списка стадий сделок по категории.
+    *   **Параметры:** `category_id: int = 0`
+    *   **Возвращает:** JSON-строка вида `{"category_id": ..., "total": ..., "stages": [...]}`.
 *   `tool://update_deal_stage`
     *   **Описание:** Обновление стадии сделки.
     *   **Параметры:** `deal_id: int`, `stage_id: str` (например, `C14:WON`)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,13 +5,13 @@
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
-import os
 import sys
+from pathlib import Path
 
-sys.path.insert(0, os.path.abspath("../../"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 project = "bitrix24-mcp"
-copyright = "2025, kartochka"
+copyright = "2025, kartochka"  # noqa: A001
 author = "kartochka"
 release = "0.1.0"
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -4,22 +4,13 @@ Quick Start
 Configuration
 ============
 
-The server requires your Bitrix24 webhook URL. You can set it in one of two ways:
+The server requires your Bitrix24 webhook URL. Set it via an environment variable before startup:
 
 1. Environment variable:
 
 .. code-block:: bash
 
    export BITRIX_WEBHOOK_URL="https://your-domain.bitrix24.ru/rest/1/yoursecretcode/"
-
-2. `.env` file:
-
-.. code-block:: ini
-
-   # .env
-   BITRIX_WEBHOOK_URL="https://your-domain.bitrix24.ru/rest/1/yoursecretcode/"
-   # Optional log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
-   # LOG_LEVEL=INFO
 
 Running the Server
 ================
@@ -28,9 +19,7 @@ After installation and configuration, start the MCP server:
 
 .. code-block:: bash
 
-   python main.py
-   # or if installed globally
-   mcp-server-b24
+   uv run bitrix24-mcp
 
 Testing the Installation
 =====================
@@ -39,4 +28,4 @@ To verify basic Bitrix24 API integration, run the test script:
 
 .. code-block:: bash
 
-   python test_services.py
+   uv run python tests/services.py

--- a/src/application/services/contact.py
+++ b/src/application/services/contact.py
@@ -5,7 +5,6 @@
 
 from typing import TYPE_CHECKING, cast
 
-
 from src.domain.entities.contact import Contact
 from src.infrastructure.bitrix.repository_factory import BitrixRepositoryFactory
 

--- a/src/application/services/deal.py
+++ b/src/application/services/deal.py
@@ -134,10 +134,17 @@ class DealService:
         """
         return await self._deal_repository.update(deal_id, deal)
 
-    async def get_deal_stages(self, category_id: int = 0) -> dict[str, Any]:
+    async def get_deal_stages(self, category_id: int = 0) -> list[dict[str, Any]]:
         """Получение списка стадий сделок для указанной категории.
 
         :param category_id: Идентификатор категории
-        :return: Словарь со стадиями сделок
+        :return: Список стадий сделок
         """
         return await self._deal_repository.get_stages(category_id)
+
+    async def get_deal_categories(self) -> list[dict[str, Any]]:
+        """Получение списка категорий сделок.
+
+        :return: Список категорий сделок
+        """
+        return await self._deal_repository.get_categories()

--- a/src/application/services/deal.py
+++ b/src/application/services/deal.py
@@ -5,7 +5,6 @@
 
 from typing import TYPE_CHECKING, Any, cast
 
-
 from src.domain.entities.deal import Deal
 from src.infrastructure.bitrix.repository_factory import BitrixRepositoryFactory
 

--- a/src/infrastructure/bitrix/bitrix_deal_repository.py
+++ b/src/infrastructure/bitrix/bitrix_deal_repository.py
@@ -57,6 +57,7 @@ class BitrixDealRepository(
     _deal_category_stage_list_method: ClassVar[str] = (
         "crm.dealcategory.stage.list"
     )
+    _bitrix_list_page_size: ClassVar[int] = 50
 
     def __init__(
         self,
@@ -140,15 +141,15 @@ class BitrixDealRepository(
             else:
                 params[self._order_param_name] = {"DATE_CREATE": "DESC"}
 
-            if limit > 50 or limit == -1:
+            if limit > self._bitrix_list_page_size or limit == -1:
                 results: list[dict[str, Any]] = await self._safe_call(
                     self.batch_list,
                     error_message,
                     [],
                     method=self._bitrix_list_method,
                     params={
-                        self._select_param_name: ["*", "UF_*"]
-                    }
+                        self._select_param_name: ["*", "UF_*"],
+                    },
                 )
                 results = results[:limit] if limit != -1 else results
             else:

--- a/src/infrastructure/bitrix/bitrix_deal_repository.py
+++ b/src/infrastructure/bitrix/bitrix_deal_repository.py
@@ -248,54 +248,59 @@ class BitrixDealRepository(
             logger.error(f"{error_message}: {e}")
             return False
 
-    async def get_categories(self) -> dict[str, Any]:
+    async def get_categories(self) -> list[dict[str, Any]]:
         """Получение списка категорий сделок.
 
-        :return: Словарь с категориями сделок
+        :return: Список категорий сделок
         """
         error_message = "Ошибка при получении списка категорий сделок"
 
         try:
-            response = await self._safe_call(
+            response: dict[str, Any] = await self._safe_call(
                 self._bitrix.call,
                 error_message,
-                None,
+                {"result": []},
                 self._deal_category_list_method,
+                {"start": 0},
+                raw=True,
             )
 
             if not response or "result" not in response:
                 logger.warning(f"{error_message}: получен некорректный ответ")
-                return {}
+                return []
 
-            return response.get("result", {})
+            result = response.get("result", [])
+            return result if isinstance(result, list) else []
         except Exception as e:
             logger.error(f"{error_message}: {e}")
-            return {}
+            return []
 
-    async def get_stages(self, category_id: int = 0) -> dict[str, Any]:
+    async def get_stages(self, category_id: int = 0) -> list[dict[str, Any]]:
         """Получение списка стадий сделок для указанной категории.
 
         :param category_id: Идентификатор категории
-        :return: Словарь со стадиями сделок
+        :return: Список стадий сделок
         """
         error_message = (
             f"Ошибка при получении стадий для категории ID={category_id}"
         )
 
         try:
-            response = await self._safe_call(
+            response: dict[str, Any] = await self._safe_call(
                 self._bitrix.call,
                 error_message,
-                None,
+                {"result": []},
                 self._deal_category_stage_list_method,
                 {"ID": category_id},
+                raw=True,
             )
 
             if not response or "result" not in response:
                 logger.warning(f"{error_message}: получен некорректный ответ")
-                return {}
+                return []
 
-            return response.get("result", {})
+            result = response.get("result", [])
+            return result if isinstance(result, list) else []
         except Exception as e:
             logger.error(f"{error_message}: {e}")
-            return {}
+            return []

--- a/src/infrastructure/ioc.py
+++ b/src/infrastructure/ioc.py
@@ -3,7 +3,7 @@
 Предоставляет единую точку инициализации и получения зависимостей.
 """
 
-from dishka import make_container, Provider, Scope, provide
+from dishka import Provider, Scope, make_container, provide
 from fast_bitrix24 import Bitrix
 
 from src.application.services.contact import ContactService
@@ -18,7 +18,7 @@ from src.infrastructure.mcp.server import BitrixMCPServer
 
 class DependencyProvider(Provider):
     """Главный провайдер зависимостей приложения."""
-    
+
     def __init__(self) -> None:
         super().__init__()
         self.bitrix_webhook_url = SettingsManager.get().BITRIX_WEBHOOK_URL
@@ -27,7 +27,7 @@ class DependencyProvider(Provider):
     def provide_bitrix_webhook_url(self) -> str:
         """Предоставляет URL вебхука Bitrix."""
         return self.bitrix_webhook_url
-    
+
     @provide(scope=Scope.APP)
     def provide_repository_factory(self) -> BitrixRepositoryFactory:
         """Создание фабрики репозиториев Bitrix24.
@@ -43,17 +43,17 @@ class DependencyProvider(Provider):
                 BitrixDealRepository(bitrix_client, contact_repository),
             ],
         )
-    
+
     @provide(scope=Scope.APP)
     def provide_mcp_server(self) -> BitrixMCPServer:
         """Предоставляет сервер MCP."""
         return BitrixMCPServer()
-    
+
     @provide(scope=Scope.APP)
     def provide_contact_service(self, repository_factory: BitrixRepositoryFactory) -> ContactService:
         """Предоставляет сервис для работы с контактами."""
         return ContactService(repository_factory)
-    
+
     @provide(scope=Scope.APP)
     def provide_deal_service(self, repository_factory: BitrixRepositoryFactory) -> DealService:
         """Предоставляет сервис для работы со сделками."""

--- a/src/infrastructure/mcp/handlers/contact.py
+++ b/src/infrastructure/mcp/handlers/contact.py
@@ -6,12 +6,12 @@
 import json
 
 from src.domain.entities.contact import Contact
+
+# Create the contact service instance.
+# In production these dependencies should come from the DI container.
+from src.infrastructure.ioc import provider
 from src.infrastructure.logging.logger import logger
 from src.infrastructure.mcp.server import BitrixMCPServer
-
-# Создаем экземпляр сервиса контактов
-# В реальном приложении эти зависимости должны предоставляться через DI контейнер
-from src.infrastructure.ioc import provider
 
 # Получаем зависимости напрямую из провайдера
 bitrix_webhook_url = provider.provide_bitrix_webhook_url()

--- a/src/infrastructure/mcp/handlers/deal.py
+++ b/src/infrastructure/mcp/handlers/deal.py
@@ -7,11 +7,11 @@ import json
 from typing import Any
 
 from src.domain.entities.deal import Deal
-from src.infrastructure.logging.logger import logger
-from src.infrastructure.mcp.server import BitrixMCPServer
 
 # Получаем зависимости напрямую из провайдера
 from src.infrastructure.ioc import provider
+from src.infrastructure.logging.logger import logger
+from src.infrastructure.mcp.server import BitrixMCPServer
 
 # Создаем зависимости напрямую
 repository_factory = provider.provide_repository_factory()
@@ -33,6 +33,12 @@ def register_deal_handlers(mcp_server: BitrixMCPServer) -> None:
         list_deals,
         name="list_deals",
         description="Получение списка сделок с возможностью фильтрации",
+    )
+
+    mcp_server.add_tool(
+        get_deal_stages,
+        name="get_deal_stages",
+        description="Получение списка стадий сделок по категории",
     )
 
     mcp_server.add_tool(
@@ -110,6 +116,32 @@ async def list_deals(
         "total": len(deals),
         "filters": filter_info,
         "deals": [json.loads(deal.to_str_json()) for deal in deals],
+    }
+
+    return json.dumps(result)
+
+
+async def get_deal_stages(
+    category_id: int = 0,
+) -> str:
+    """Получение списка стадий сделки по категории (инструмент).
+
+    :param category_id: Идентификатор категории сделок
+    :return: JSON-строка со списком стадий
+    """
+    if category_id < 0:
+        return json.dumps(
+            {
+                "error": "Недопустимое значение category_id. Используйте 0 или положительное целое число",
+            },
+        )
+
+    stages = await deal_service.get_deal_stages(category_id)
+
+    result = {
+        "category_id": category_id,
+        "total": len(stages),
+        "stages": stages,
     }
 
     return json.dumps(result)

--- a/tests/services.py
+++ b/tests/services.py
@@ -1,5 +1,4 @@
-"""
-Тестовый скрипт для проверки работы сервисов Bitrix24.
+"""Тестовый скрипт для проверки работы сервисов Bitrix24.
 
 Запускает по одному методу каждого сервиса для проверки их работоспособности.
 """
@@ -14,110 +13,116 @@ from src.infrastructure.logging.logger import logger
 
 
 async def test_contact_service() -> dict[str, Any]:
-    """
-    Тестирование сервиса контактов.
+    """Тестирование сервиса контактов.
 
     :return: Результаты тестирования
     """
-    logger.info('Тестирование сервиса контактов')
+    logger.info("Тестирование сервиса контактов")
 
     contact_service = container.get(ContactService)
     results = {}
 
     contacts = await contact_service.list_contacts(limit=5)
-    results['list_contacts'] = {
-        'success': len(contacts) >= 0,
-        'count': len(contacts),
-        'first_contact_id': contacts[0].id if contacts else None,
+    results["list_contacts"] = {
+        "success": len(contacts) >= 0,
+        "count": len(contacts),
+        "first_contact_id": contacts[0].id if contacts else None,
     }
 
     if contacts:
         contact_id = contacts[0].id
         contact = await contact_service.get_contact_by_id(contact_id)
-        results['get_contact_by_id'] = {
-            'success': contact is not None,
-            'contact_id': contact_id,
-            'name': contact.get_full_name() if contact else None,
+        results["get_contact_by_id"] = {
+            "success": contact is not None,
+            "contact_id": contact_id,
+            "name": contact.get_full_name() if contact else None,
         }
 
         if contact and contact.name:
             search_query = contact.name
             search_results = await contact_service.search_contacts(
                 search_query,
-                'name',
+                "name",
                 5,
             )
-            results['search_contacts'] = {
-                'success': len(search_results) >= 0,
-                'query': search_query,
-                'count': len(search_results),
+            results["search_contacts"] = {
+                "success": len(search_results) >= 0,
+                "query": search_query,
+                "count": len(search_results),
             }
 
     return results
 
 
 async def test_deal_service() -> dict[str, Any]:
-    """
-    Тестирование сервиса сделок.
+    """Тестирование сервиса сделок.
 
     :return: Результаты тестирования
     """
-    logger.info('Тестирование сервиса сделок')
+    logger.info("Тестирование сервиса сделок")
 
     deal_service = container.get(DealService)
     results = {}
 
     deals = await deal_service.list_deals(active_only=True)
-    results['list_deals'] = {
-        'success': len(deals) >= 0,
-        'count': len(deals),
-        'first_deal_id': deals[0].id if deals else None,
+    results["list_deals"] = {
+        "success": len(deals) >= 0,
+        "count": len(deals),
+        "first_deal_id": deals[0].id if deals else None,
+    }
+
+    stages = await deal_service.get_deal_stages()
+    results["get_deal_stages"] = {
+        "success": isinstance(stages, list),
+        "count": len(stages),
+    }
+
+    categories = await deal_service.get_deal_categories()
+    results["get_deal_categories"] = {
+        "success": isinstance(categories, list),
+        "count": len(categories),
     }
 
     if deals:
         deal_id = deals[0].id
         deal = await deal_service.get_deal_by_id(deal_id)
-        results['get_deal_by_id'] = {
-            'success': deal is not None,
-            'deal_id': deal_id,
-            'title': deal.title if deal else None,
+        results["get_deal_by_id"] = {
+            "success": deal is not None,
+            "deal_id": deal_id,
+            "title": deal.title if deal else None,
         }
 
     return results
 
 
 async def run_tests() -> None:
-    """
-    Запуск всех тестов.
-    """
+    """Запуск всех тестов."""
     try:
-        logger.info('Запуск тестирования сервисов Bitrix24')
+        logger.info("Запуск тестирования сервисов Bitrix24")
 
         contact_results = await test_contact_service()
         deal_results = await test_deal_service()
 
-        logger.info('===== Результаты тестирования =====')
-        logger.info(f'Сервис контактов: {contact_results}')
-        logger.info(f'Сервис сделок: {deal_results}')
+        logger.info("===== Результаты тестирования =====")
+        logger.info(f"Сервис контактов: {contact_results}")
+        logger.info(f"Сервис сделок: {deal_results}")
 
-        logger.info('Тестирование завершено успешно')
+        logger.info("Тестирование завершено успешно")
     except Exception as e:
-        logger.error(f'Ошибка при выполнении тестов: {e}')
+        logger.error(f"Ошибка при выполнении тестов: {e}")
         raise
 
 
 def main() -> None:
-    """
-    Точка входа в скрипт тестирования.
-    """
+    """Точка входа в скрипт тестирования."""
     try:
         asyncio.run(run_tests())
     except KeyboardInterrupt:
-        logger.info('Тестирование прервано пользователем')
+        logger.info("Тестирование прервано пользователем")
     except Exception as e:
-        logger.error(f'Критическая ошибка: {e}')
+        logger.error(f"Критическая ошибка: {e}")
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add the `get_deal_stages` MCP tool and expose deal stage metadata through the handler
- fix repository parsing for `crm.dealcategory.stage.list` and `crm.dealcategory.list` by using raw list responses
- add `DealService.get_deal_categories()` and extend the smoke script to validate both stages and categories
- align README and quickstart examples with the current runtime commands and tool surface

## Validation
- `py -3.12 -m py_compile src/infrastructure/mcp/handlers/deal.py src/infrastructure/bitrix/bitrix_deal_repository.py src/application/services/deal.py tests/services.py`
- `BITRIX_WEBHOOK_URL=<redacted> py -3.12 tests/services.py`
- direct live calls for `get_deal_stages()` and `get_deal_categories()` against a working Bitrix24 webhook